### PR TITLE
serial: migrate to lib.wiring components.

### DIFF
--- a/amaranth_stdio/serial.py
+++ b/amaranth_stdio/serial.py
@@ -1,110 +1,198 @@
 from amaranth import *
+from amaranth.lib import enum, data, wiring
+from amaranth.lib.wiring import In, Out, connect, flipped
 from amaranth.lib.cdc import FFSynchronizer
 from amaranth.utils import bits_for
 
 
-__all__ = ["AsyncSerialRX", "AsyncSerialTX", "AsyncSerial"]
+__all__ = ["Parity", "AsyncSerialRX", "AsyncSerialTX", "AsyncSerial"]
 
 
-def _check_divisor(divisor, bound):
-    if divisor < bound:
-        raise ValueError("Invalid divisor {!r}; must be greater than or equal to {}"
-                         .format(divisor, bound))
+class Parity(enum.Enum):
+    """Asynchronous serial parity mode."""
+    NONE  = "none"
+    MARK  = "mark"
+    SPACE = "space"
+    EVEN  = "even"
+    ODD   = "odd"
+
+    def _compute_bit(self, data):
+        cast_data = Value.cast(data)
+        if self == self.NONE:
+            return Const(0, 0)
+        if self == self.MARK:
+            return Const(1, 1)
+        if self == self.SPACE:
+            return Const(0, 1)
+        if self == self.EVEN:
+            return cast_data.xor()
+        if self == self.ODD:
+            return ~cast_data.xor()
+        assert False # :nocov:
 
 
-def _check_parity(parity):
-    choices = ("none", "mark", "space", "even", "odd")
-    if parity not in choices:
-        raise ValueError("Invalid parity {!r}; must be one of {}"
-                         .format(parity, ", ".join(choices)))
+class _FrameLayout(data.StructLayout):
+    def __init__(self, data_bits, parity):
+        super().__init__({
+            "start":  unsigned(1),
+            "data":   unsigned(data_bits),
+            "parity": unsigned(0 if parity == Parity.NONE else 1),
+            "stop":   unsigned(1),
+        })
 
 
-def _compute_parity_bit(data, parity):
-    if parity == "none":
-        return C(0, 0)
-    if parity == "mark":
-        return C(1, 1)
-    if parity == "space":
-        return C(0, 1)
-    if parity == "even":
-        return data.xor()
-    if parity == "odd":
-        return ~data.xor()
-    assert False
+class AsyncSerialRX(wiring.Component):
+    class Signature(wiring.Signature):
+        """Asynchronous serial receiver signature.
 
+        Parameters
+        ----------
+        divisor : int
+            Clock divisor initial value. Should be set to ``int(clk_frequency // baudrate)``.
+        divisor_bits : int
+            Clock divisor width. Optional. If omitted, ``bits_for(divisor)`` is used instead.
+        data_bits : int
+            Data bits per frame.
+        parity : :class:`Parity`
+            Parity mode.
 
-def _wire_layout(data_bits, parity="none"):
-    return [
-        ("start",  1),
-        ("data",   data_bits),
-        ("parity", 0 if parity == "none" else 1),
-        ("stop",   1),
-    ]
+        Interface attributes
+        --------------------
+        divisor : Signal, in
+            Clock divisor.
+        data : Signal, out
+            Read data. Valid only when ``rdy`` is asserted.
+        err.overflow : Signal, out
+            Error flag. A new frame has been received, but the previous one was not acknowledged.
+        err.frame : Signal, out
+            Error flag. The received bits do not fit in a frame.
+        err.parity : Signal, out
+            Error flag. The parity check has failed.
+        rdy : Signal, out
+            Read strobe.
+        ack : Signal, in
+            Read acknowledge. Must be held asserted while data can be read out of the receiver.
+        i : Signal, in
+            Serial input.
 
+        Raises
+        ------
+        See :meth:`AsyncSerialRX.Signature.check_parameters`.
+        """
+        def __init__(self, *, divisor, divisor_bits=None, data_bits=8, parity="none"):
+            self.check_parameters(divisor=divisor, divisor_bits=divisor_bits, data_bits=data_bits,
+                                  parity=parity)
+            self._divisor      = divisor
+            self._divisor_bits = divisor_bits if divisor_bits is not None else bits_for(divisor)
+            self._data_bits    = data_bits
+            self._parity       = Parity(parity)
 
-class AsyncSerialRX(Elaboratable):
+            super().__init__({
+                "divisor": In(unsigned(self._divisor_bits), reset=self._divisor),
+                "data":    Out(unsigned(self._data_bits)),
+                "err":     Out(data.StructLayout({"overflow": 1, "frame": 1, "parity": 1})),
+                "rdy":     Out(unsigned(1)),
+                "ack":     In(unsigned(1)),
+                "i":       In(unsigned(1), reset=1),
+            })
+
+        @classmethod
+        def check_parameters(cls, *, divisor, divisor_bits=None, data_bits=8, parity="none"):
+            """Validate signature parameters.
+
+            Raises
+            ------
+            :exc:`TypeError`
+                If ``divisor`` is not an integer greater than or equal to 5.
+            :exc:`TypeError`
+                If ``divisor_bits`` is not `None` and not an integer greater than or equal to
+                ``bits_for(divisor)``.
+            :exc:`TypeError`
+                If ``data_bits`` is not an integer greater than or equal to 0.
+            :exc:`ValueError`
+                If ``parity`` is not a :class:`Parity` member.
+            """
+            # The clock divisor must be >= 5 to keep the receiver FSM synchronized with its input
+            # during a DONE->IDLE->BUSY transition.
+            AsyncSerial.Signature._check_divisor(divisor, divisor_bits, min_divisor=5)
+            if not isinstance(data_bits, int) or data_bits < 0:
+                raise TypeError(f"Data bits must be a non-negative integer, not {data_bits!r}")
+            # Raise a ValueError if parity is invalid.
+            Parity(parity)
+
+        @property
+        def divisor(self):
+            return self._divisor
+
+        @property
+        def divisor_bits(self):
+            return self._divisor_bits
+
+        @property
+        def data_bits(self):
+            return self._data_bits
+
+        @property
+        def parity(self):
+            return self._parity
+
+        def __eq__(self, other):
+            """Compare signatures.
+
+            Two signatures are equal if they have the same divisor value, divisor bits,
+            data bits, and parity.
+            """
+            return (isinstance(other, AsyncSerialRX.Signature) and
+                    self.divisor == other.divisor and
+                    self.divisor_bits == other.divisor_bits and
+                    self.data_bits == other.data_bits and
+                    self.parity == other.parity)
+
+        def __repr__(self):
+            return f"AsyncSerialRX.Signature({self.members!r})"
+
     """Asynchronous serial receiver.
 
     Parameters
     ----------
     divisor : int
-        Clock divisor reset value. Should be set to ``int(clk_frequency // baudrate)``.
+        Clock divisor initial value. Should be set to ``int(clk_frequency // baudrate)``.
     divisor_bits : int
-        Optional. Clock divisor width. If omitted, ``bits_for(divisor)`` is used instead.
+        Clock divisor width. Optional. If omitted, ``bits_for(divisor)`` is used instead.
     data_bits : int
-        Data width.
-    parity : ``"none"``, ``"mark"``, ``"space"``, ``"even"``, ``"odd"``
+        Data bits per frame.
+    parity : :class:`Parity`
         Parity mode.
     pins : :class:`amaranth.lib.io.Pin`
-        Optional. UART pins. See :class:`amaranth_boards.resources.UARTResource` for layout.
+        UART pins. Optional. See :class:`amaranth_boards.resources.UARTResource` for layout.
+        If provided, the ``i`` port of the receiver is internally connected to ``pins.rx.i``.
 
-    Attributes
-    ----------
-    divisor : Signal, in
-        Clock divisor.
-    data : Signal, out
-        Read data. Valid only when ``rdy`` is asserted.
-    err.overflow : Signal, out
-        Error flag. A new frame has been received, but the previous one was not acknowledged.
-    err.frame : Signal, out
-        Error flag. The received bits do not fit in a frame.
-    err.parity : Signal, out
-        Error flag. The parity check has failed.
-    rdy : Signal, out
-        Read strobe.
-    ack : Signal, in
-        Read acknowledge. Must be held asserted while data can be read out of the receiver.
-    i : Signal, in
-        Serial input. If ``pins`` has been specified, ``pins.rx.i`` drives it.
+    Raises
+    ------
+    See :meth:`AsyncSerialRX.Signature.check_parameters`.
     """
     def __init__(self, *, divisor, divisor_bits=None, data_bits=8, parity="none", pins=None):
-        _check_parity(parity)
-        self._parity = parity
+        self.Signature.check_parameters(divisor=divisor, divisor_bits=divisor_bits,
+                                        data_bits=data_bits, parity=parity)
+        self._divisor      = divisor
+        self._divisor_bits = divisor_bits if divisor_bits is not None else bits_for(divisor)
+        self._data_bits    = data_bits
+        self._parity       = Parity(parity)
+        self._pins         = pins
 
-        # The clock divisor must be at least 5 to keep the FSM synchronized with the serial input
-        # during a DONE->IDLE->BUSY transition.
-        _check_divisor(divisor, 5)
-        self.divisor = Signal(divisor_bits or bits_for(divisor), reset=divisor)
+        super().__init__()
 
-        self.data = Signal(data_bits)
-        self.err  = Record([
-            ("overflow", 1),
-            ("frame",    1),
-            ("parity",   1),
-        ])
-        self.rdy  = Signal()
-        self.ack  = Signal()
-
-        self.i    = Signal(reset=1)
-
-        self._pins = pins
+    @property
+    def signature(self):
+        return self.Signature(divisor=self._divisor, divisor_bits=self._divisor_bits,
+                              data_bits=self._data_bits, parity=self._parity)
 
     def elaborate(self, platform):
         m = Module()
 
         timer = Signal.like(self.divisor)
-        shreg = Record(_wire_layout(len(self.data), self._parity))
-        bitno = Signal(range(len(shreg)))
+        shreg = Signal(_FrameLayout(self._data_bits, self._parity))
+        bitno = Signal(range(len(shreg.as_value())))
 
         if self._pins is not None:
             m.submodules += FFSynchronizer(self._pins.rx.i, self.i, reset=1)
@@ -113,7 +201,7 @@ class AsyncSerialRX(Elaboratable):
             with m.State("IDLE"):
                 with m.If(~self.i):
                     m.d.sync += [
-                        bitno.eq(len(shreg) - 1),
+                        bitno.eq(len(shreg.as_value()) - 1),
                         timer.eq(self.divisor >> 1),
                     ]
                     m.next = "BUSY"
@@ -123,7 +211,7 @@ class AsyncSerialRX(Elaboratable):
                     m.d.sync += timer.eq(timer - 1)
                 with m.Else():
                     m.d.sync += [
-                        shreg.eq(Cat(shreg[1:], self.i)),
+                        shreg.eq(Cat(shreg.as_value()[1:], self.i)),
                         bitno.eq(bitno - 1),
                         timer.eq(self.divisor - 1),
                     ]
@@ -136,7 +224,7 @@ class AsyncSerialRX(Elaboratable):
                         self.data.eq(shreg.data),
                         self.err.frame .eq(~((shreg.start == 0) & (shreg.stop == 1))),
                         self.err.parity.eq(~(shreg.parity ==
-                                             _compute_parity_bit(shreg.data, self._parity))),
+                                             self._parity._compute_bit(shreg.data))),
                     ]
                 m.d.sync += self.err.overflow.eq(~self.ack)
                 m.next = "IDLE"
@@ -147,56 +235,149 @@ class AsyncSerialRX(Elaboratable):
         return m
 
 
-class AsyncSerialTX(Elaboratable):
+class AsyncSerialTX(wiring.Component):
+    class Signature(wiring.Signature):
+        """Asynchronous serial transmitter signature.
+
+        Parameters
+        ----------
+        divisor : int
+            Clock divisor initial value. Should be set to ``int(clk_frequency // baudrate)``.
+        divisor_bits : int
+            Clock divisor width. Optional. If omitted, ``bits_for(divisor)`` is used instead.
+        data_bits : int
+            Data bits per frame.
+        parity : :class:`Parity`
+            Parity mode.
+
+        Interface attributes
+        --------------------
+        divisor : Signal, in
+            Clock divisor.
+        data : Signal, in
+            Write data. Valid only when ``ack`` is asserted.
+        rdy : Signal, out
+            Write ready. Asserted when the transmitter is ready to transmit data.
+        ack : Signal, in
+            Write strobe. Data gets transmitted when both ``rdy`` and ``ack`` are asserted.
+        o : Signal, out
+            Serial output.
+
+        Raises
+        ------
+        See :meth:`AsyncSerialTX.Signature.check_parameters`.
+        """
+        def __init__(self, *, divisor, divisor_bits=None, data_bits=8, parity="none"):
+            self.check_parameters(divisor=divisor, divisor_bits=divisor_bits, data_bits=data_bits,
+                                  parity=parity)
+            self._divisor      = divisor
+            self._divisor_bits = divisor_bits if divisor_bits is not None else bits_for(divisor)
+            self._data_bits    = data_bits
+            self._parity       = Parity(parity)
+
+            super().__init__({
+                "divisor": In(unsigned(self._divisor_bits), reset=self._divisor),
+                "data":    In(unsigned(self._data_bits)),
+                "rdy":     Out(unsigned(1)),
+                "ack":     In(unsigned(1)),
+                "o":       Out(unsigned(1), reset=1),
+            })
+
+        @classmethod
+        def check_parameters(cls, *, divisor, divisor_bits=None, data_bits=8, parity="none"):
+            """Validate signature parameters.
+
+            Raises
+            ------
+            :exc:`TypeError`
+                If ``divisor`` is not an integer greater than or equal to 1.
+            :exc:`TypeError`
+                If ``divisor_bits`` is not `None` and not an integer greater than or equal to
+                ``bits_for(divisor)``.
+            :exc:`TypeError`
+                If ``data_bits`` is not an integer greater than or equal to 0.
+            :exc:`ValueError`
+                If ``parity`` is not a :class:`Parity` member.
+            """
+            AsyncSerial.Signature._check_divisor(divisor, divisor_bits, min_divisor=1)
+            if not isinstance(data_bits, int) or data_bits < 0:
+                raise TypeError(f"Data bits must be a non-negative integer, not {data_bits!r}")
+            # Raise a ValueError if parity is invalid.
+            Parity(parity)
+
+        @property
+        def divisor(self):
+            return self._divisor
+
+        @property
+        def divisor_bits(self):
+            return self._divisor_bits
+
+        @property
+        def data_bits(self):
+            return self._data_bits
+
+        @property
+        def parity(self):
+            return self._parity
+
+        def __eq__(self, other):
+            """Compare signatures.
+
+            Two signatures are equal if they have the same divisor value, divisor bits,
+            data bits, and parity.
+            """
+            return (isinstance(other, AsyncSerialTX.Signature) and
+                    self.divisor == other.divisor and
+                    self.divisor_bits == other.divisor_bits and
+                    self.data_bits == other.data_bits and
+                    self.parity == other.parity)
+
+        def __repr__(self):
+            return f"AsyncSerialTX.Signature({self.members!r})"
+
     """Asynchronous serial transmitter.
 
     Parameters
     ----------
     divisor : int
-        Clock divisor reset value. Should be set to ``int(clk_frequency // baudrate)``.
+        Clock divisor initial value. Should be set to ``int(clk_frequency // baudrate)``.
     divisor_bits : int
-        Optional. Clock divisor width. If omitted, ``bits_for(divisor)`` is used instead.
+        Clock divisor width. Optional. If omitted, ``bits_for(divisor)`` is used instead.
     data_bits : int
-        Data width.
-    parity : ``"none"``, ``"mark"``, ``"space"``, ``"even"``, ``"odd"``
+        Data bits per frame.
+    parity : :class:`Parity`
         Parity mode.
     pins : :class:`amaranth.lib.io.Pin`
-        Optional. UART pins. See :class:`amaranth_boards.resources.UARTResource` for layout.
+        UART pins. Optional. See :class:`amaranth_boards.resources.UARTResource` for layout.
+        If provided, the ``o`` port of the transmitter is internally connected to ``pins.tx.o``.
 
-    Attributes
-    ----------
-    divisor : Signal, in
-        Clock divisor.
-    data : Signal, in
-        Write data. Valid only when ``ack`` is asserted.
-    rdy : Signal, out
-        Write ready. Asserted when the transmitter is ready to transmit data.
-    ack : Signal, in
-        Write strobe. Data gets transmitted when both ``rdy`` and ``ack`` are asserted.
-    o : Signal, out
-        Serial output. If ``pins`` has been specified, it drives ``pins.tx.o``.
+    Raises
+    ------
+    See :class:`AsyncSerialTX.Signature.check_parameters`.
     """
     def __init__(self, *, divisor, divisor_bits=None, data_bits=8, parity="none", pins=None):
-        _check_parity(parity)
-        self._parity = parity
+        self.Signature.check_parameters(divisor=divisor, divisor_bits=divisor_bits,
+                                        data_bits=data_bits, parity=parity)
+        self._divisor      = divisor
+        self._divisor_bits = divisor_bits if divisor_bits is not None else bits_for(divisor)
+        self._data_bits    = data_bits
+        self._parity       = Parity(parity)
+        self._pins         = pins
 
-        _check_divisor(divisor, 1)
-        self.divisor = Signal(divisor_bits or bits_for(divisor), reset=divisor)
+        super().__init__()
 
-        self.data = Signal(data_bits)
-        self.rdy  = Signal()
-        self.ack  = Signal()
-
-        self.o    = Signal(reset=1)
-
-        self._pins = pins
+    @property
+    def signature(self):
+        return self.Signature(divisor=self._divisor, divisor_bits=self._divisor_bits,
+                              data_bits=self._data_bits, parity=self._parity)
 
     def elaborate(self, platform):
         m = Module()
 
         timer = Signal.like(self.divisor)
-        shreg = Record(_wire_layout(len(self.data), self._parity))
-        bitno = Signal(range(len(shreg)))
+        shreg = Signal(_FrameLayout(len(self.data), self._parity))
+        bitno = Signal(range(len(shreg.as_value())))
 
         if self._pins is not None:
             m.d.comb += self._pins.tx.o.eq(self.o)
@@ -208,9 +389,9 @@ class AsyncSerialTX(Elaboratable):
                     m.d.sync += [
                         shreg.start .eq(0),
                         shreg.data  .eq(self.data),
-                        shreg.parity.eq(_compute_parity_bit(self.data, self._parity)),
+                        shreg.parity.eq(self._parity._compute_bit(self.data)),
                         shreg.stop  .eq(1),
-                        bitno.eq(len(shreg) - 1),
+                        bitno.eq(len(shreg.as_value()) - 1),
                         timer.eq(self.divisor - 1),
                     ]
                     m.next = "BUSY"
@@ -230,43 +411,170 @@ class AsyncSerialTX(Elaboratable):
         return m
 
 
-class AsyncSerial(Elaboratable):
+class AsyncSerial(wiring.Component):
+    class Signature(wiring.Signature):
+        """Asynchronous serial transceiver signature.
+
+        Parameters
+        ----------
+        divisor : int
+            Clock divisor initial value. Should be set to ``int(clk_frequency // baudrate)``.
+        divisor_bits : int
+            Clock divisor width. Optional. If omitted, ``bits_for(divisor)`` is used instead.
+        data_bits : int
+            Data bits per frame.
+        parity : :class:`Parity`
+            Parity mode.
+
+        Interface attributes
+        --------------------
+        divisor : Signal, in
+            Clock divisor. It is internally connected to ``rx.divisor`` and ``tx.divisor``.
+        rx : :class:`wiring.Interface`
+            Receiver interface. See :class:`AsyncSerialRX.Signature`.
+        tx : :class:`wiring.Interface`
+            Transmitter interface. See :class:`AsyncSerialTX.Signature`.
+
+        Raises
+        ------
+        See :meth:`AsyncSerial.Signature.check_parameters`.
+        """
+        def __init__(self, *, divisor, divisor_bits=None, data_bits=8, parity="none"):
+            rx_sig = AsyncSerialRX.Signature(divisor=divisor, divisor_bits=divisor_bits,
+                                             data_bits=data_bits, parity=parity)
+            tx_sig = AsyncSerialTX.Signature(divisor=divisor, divisor_bits=divisor_bits,
+                                             data_bits=data_bits, parity=parity)
+
+            assert rx_sig.members["divisor"] == tx_sig.members["divisor"]
+            divisor_shape = rx_sig.members["divisor"].shape
+            divisor_reset = rx_sig.members["divisor"].reset
+
+            super().__init__({
+                "divisor": In(divisor_shape, reset=divisor_reset),
+                "rx":      Out(rx_sig),
+                "tx":      Out(tx_sig),
+            })
+
+        @classmethod
+        def _check_divisor(cls, divisor, divisor_bits, min_divisor=1):
+            if not isinstance(divisor, int) or divisor < min_divisor:
+                raise TypeError(f"Divisor initial value must be an integer greater than or equal "
+                                f"to {min_divisor}, not {divisor!r}")
+            if divisor_bits is not None:
+                min_divisor_bits = bits_for(divisor)
+                if not isinstance(divisor_bits, int) or divisor_bits < min_divisor_bits:
+                    raise TypeError(f"Divisor bits must be an integer greater than or equal to "
+                                    f"{min_divisor_bits}, not {divisor_bits!r}")
+
+        @classmethod
+        def check_parameters(cls, *, divisor, divisor_bits=None, data_bits=8, parity="none"):
+            """Validate signature parameters.
+
+            Raises
+            ------
+            :exc:`TypeError`
+                If ``divisor`` is not an integer greater than or equal to 5.
+            :exc:`TypeError`
+                If ``divisor_bits`` is not `None` and not an integer greater than or equal to
+                ``bits_for(divisor)``.
+            :exc:`TypeError`
+                If ``data_bits`` is not an integer greater than or equal to 0.
+            :exc:`ValueError`
+                If ``parity`` is not a :class:`Parity` member.
+            """
+            AsyncSerialRX.Signature.check_parameters(divisor=divisor, divisor_bits=divisor_bits,
+                                                     data_bits=data_bits, parity=parity)
+            AsyncSerialTX.Signature.check_parameters(divisor=divisor, divisor_bits=divisor_bits,
+                                                     data_bits=data_bits, parity=parity)
+
+        @property
+        def divisor(self):
+            return self.members["rx"].signature.divisor
+
+        @property
+        def divisor_bits(self):
+            return self.members["rx"].signature.divisor_bits
+
+        @property
+        def data_bits(self):
+            return self.members["rx"].signature.data_bits
+
+        @property
+        def parity(self):
+            return self.members["rx"].signature.parity
+
+        def __eq__(self, other):
+            """Compare signatures.
+
+            Two signatures are equal if they have the same divisor value, divisor bits,
+            data bits, and parity.
+            """
+            return (isinstance(other, AsyncSerial.Signature) and
+                    self.divisor == other.divisor and
+                    self.divisor_bits == other.divisor_bits and
+                    self.data_bits == other.data_bits and
+                    self.parity == other.parity)
+
+        def __repr__(self):
+            return f"AsyncSerial.Signature({self.members!r})"
+
     """Asynchronous serial transceiver.
 
     Parameters
     ----------
     divisor : int
-        Clock divisor reset value. Should be set to ``int(clk_frequency // baudrate)``.
+        Clock divisor initial value. Should be set to ``int(clk_frequency // baudrate)``.
     divisor_bits : int
-        Optional. Clock divisor width. If omitted, ``bits_for(divisor)`` is used instead.
+        Clock divisor width. Optional. If omitted, ``bits_for(divisor)`` is used instead.
     data_bits : int
-        Data width.
-    parity : ``"none"``, ``"mark"``, ``"space"``, ``"even"``, ``"odd"``
+        Data bits per frame.
+    parity : :class:`Parity`
         Parity mode.
     pins : :class:`amaranth.lib.io.Pin`
-        Optional. UART pins. See :class:`amaranth_boards.resources.UARTResource` for layout.
+        UART pins. Optional. See :class:`amaranth_boards.resources.UARTResource` for layout.
+        If provided, the ``rx.i`` and ``tx.o`` ports of the transceiver are internally connected
+        to ``pins.rx.i`` and ``pins.tx.o``, respectively.
 
-    Attributes
-    ----------
-    divisor : Signal, in
-        Clock divisor.
-    rx : :class:`AsyncSerialRX`
-        See :class:`AsyncSerialRX`.
-    tx : :class:`AsyncSerialTX`
-        See :class:`AsyncSerialTX`.
+    Raises
+    ------
+    See :meth:`AsyncSerial.Signature.check_parameters`.
     """
-    def __init__(self, *, divisor, divisor_bits=None, **kwargs):
-        self.divisor = Signal(divisor_bits or bits_for(divisor), reset=divisor)
+    def __init__(self, *, divisor, divisor_bits=None, data_bits=8, parity="none", pins=None):
+        self.Signature.check_parameters(divisor=divisor, divisor_bits=divisor_bits,
+                                        data_bits=data_bits, parity=parity)
+        self._divisor      = divisor
+        self._divisor_bits = divisor_bits if divisor_bits is not None else bits_for(divisor)
+        self._data_bits    = data_bits
+        self._parity       = Parity(parity)
+        self._pins         = pins
 
-        self.rx = AsyncSerialRX(divisor=divisor, divisor_bits=divisor_bits, **kwargs)
-        self.tx = AsyncSerialTX(divisor=divisor, divisor_bits=divisor_bits, **kwargs)
+        super().__init__()
+
+    @property
+    def signature(self):
+        return self.Signature(divisor=self._divisor, divisor_bits=self._divisor_bits,
+                              data_bits=self._data_bits, parity=self._parity)
 
     def elaborate(self, platform):
         m = Module()
-        m.submodules.rx = self.rx
-        m.submodules.tx = self.tx
+
+        rx = AsyncSerialRX(divisor=self._divisor, divisor_bits=self._divisor_bits,
+                           data_bits=self._data_bits, parity=self._parity)
+        tx = AsyncSerialTX(divisor=self._divisor, divisor_bits=self._divisor_bits,
+                           data_bits=self._data_bits, parity=self._parity)
+        m.submodules.rx = rx
+        m.submodules.tx = tx
+
         m.d.comb += [
             self.rx.divisor.eq(self.divisor),
             self.tx.divisor.eq(self.divisor),
         ]
+
+        if self._pins is not None:
+            m.submodules += FFSynchronizer(self._pins.rx.i, self.rx.i, reset=1)
+            m.d.comb += self._pins.tx.o.eq(self.tx.o)
+
+        connect(m, flipped(self.rx), rx)
+        connect(m, flipped(self.tx), tx)
+
         return m


### PR DESCRIPTION
As a breaking change, `divisor_bits` must now be greater than or equal to `bits_for(divisor)`.