### PR TITLE
Follow RFCs 43 and 47

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,10 +23,9 @@ jobs:
         - 'pypy-3.10'
         # this version range needs to be synchronized with the one in pyproject.toml
         amaranth-version:
-        - '0.4'
         - 'git'
         allow-failure:
-          - false
+        - false
     continue-on-error: '${{ matrix.allow-failure }}'
     name: 'test (${{ matrix.python-version }}, HDL ${{ matrix.amaranth-version }})'
     steps:

--- a/amaranth_stdio/serial.py
+++ b/amaranth_stdio/serial.py
@@ -88,12 +88,12 @@ class AsyncSerialRX(wiring.Component):
             self._parity       = Parity(parity)
 
             super().__init__({
-                "divisor": In(unsigned(self._divisor_bits), reset=self._divisor),
+                "divisor": In(unsigned(self._divisor_bits), init=self._divisor),
                 "data":    Out(unsigned(self._data_bits)),
                 "err":     Out(data.StructLayout({"overflow": 1, "frame": 1, "parity": 1})),
                 "rdy":     Out(unsigned(1)),
                 "ack":     In(unsigned(1)),
-                "i":       In(unsigned(1), reset=1),
+                "i":       In(unsigned(1), init=1),
             })
 
         @classmethod
@@ -184,7 +184,7 @@ class AsyncSerialRX(wiring.Component):
         bitno = Signal(range(len(shreg.as_value())))
 
         if self._pins is not None:
-            m.submodules += FFSynchronizer(self._pins.rx.i, self.i, reset=1)
+            m.submodules += FFSynchronizer(self._pins.rx.i, self.i, init=1)
 
         with m.FSM() as fsm:
             with m.State("IDLE"):
@@ -265,11 +265,11 @@ class AsyncSerialTX(wiring.Component):
             self._parity       = Parity(parity)
 
             super().__init__({
-                "divisor": In(unsigned(self._divisor_bits), reset=self._divisor),
+                "divisor": In(unsigned(self._divisor_bits), init=self._divisor),
                 "data":    In(unsigned(self._data_bits)),
                 "rdy":     Out(unsigned(1)),
                 "ack":     In(unsigned(1)),
-                "o":       Out(unsigned(1), reset=1),
+                "o":       Out(unsigned(1), init=1),
             })
 
         @classmethod
@@ -425,10 +425,10 @@ class AsyncSerial(wiring.Component):
 
             assert rx_sig.members["divisor"] == tx_sig.members["divisor"]
             divisor_shape = rx_sig.members["divisor"].shape
-            divisor_reset = rx_sig.members["divisor"].reset
+            divisor_init  = rx_sig.members["divisor"].init
 
             super().__init__({
-                "divisor": In(divisor_shape, reset=divisor_reset),
+                "divisor": In(divisor_shape, init=divisor_init),
                 "rx":      Out(rx_sig),
                 "tx":      Out(tx_sig),
             })
@@ -542,7 +542,7 @@ class AsyncSerial(wiring.Component):
         ]
 
         if self._pins is not None:
-            m.submodules += FFSynchronizer(self._pins.rx.i, self.rx.i, reset=1)
+            m.submodules += FFSynchronizer(self._pins.rx.i, self.rx.i, init=1)
             m.d.comb += self._pins.tx.o.eq(self.tx.o)
 
         connect(m, flipped(self.rx), rx)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ license = {file = "LICENSE.txt"}
 requires-python = "~=3.8"
 dependencies = [
   # this version requirement needs to be synchronized with the one in .github/workflows/main.yml
-  "amaranth>=0.4,<0.5",
+  "amaranth @ git+https://github.com/amaranth-lang/amaranth",
 ]
 
 [project.urls]

--- a/tests/test_serial.py
+++ b/tests/test_serial.py
@@ -5,7 +5,6 @@ from unittest import TestCase
 from amaranth import *
 from amaranth.lib.data import StructLayout
 from amaranth.lib.fifo import SyncFIFO
-from amaranth.lib.io import pin_layout
 from amaranth.lib.wiring import *
 from amaranth.sim import *
 

--- a/tests/test_serial.py
+++ b/tests/test_serial.py
@@ -15,7 +15,7 @@ def simulation_test(dut, process):
     sim = Simulator(dut)
     with sim.write_vcd("test.vcd"):
         sim.add_clock(1e-6)
-        sim.add_sync_process(process)
+        sim.add_testbench(process)
         sim.run()
 
 
@@ -111,7 +111,7 @@ class AsyncSerialRXSignatureTestCase(TestCase):
 class AsyncSerialRXTestCase(TestCase):
     def tx_period(self):
         for _ in range((yield self.dut.divisor)):
-            yield
+            yield Tick()
 
     def tx_bits(self, bits, pins=None):
         if pins is not None:
@@ -128,7 +128,7 @@ class AsyncSerialRXTestCase(TestCase):
             yield self.dut.ack.eq(1)
             yield from self.tx_bits(bits, pins)
             while not (yield self.dut.rdy):
-                yield
+                yield Tick()
             if data is not None:
                 self.assertFalse((yield self.dut.err.overflow))
                 self.assertFalse((yield self.dut.err.frame))
@@ -202,7 +202,7 @@ class AsyncSerialRXTestCase(TestCase):
             self.assertFalse((yield self.dut.rdy))
             yield from self.tx_bits([0, 0,0,0,0,0,0,0,0, 1])
             yield from self.tx_period()
-            yield
+            yield Tick()
             self.assertFalse((yield self.dut.rdy))
             self.assertTrue((yield self.dut.err.overflow))
         simulation_test(self.dut, process)
@@ -224,12 +224,11 @@ class AsyncSerialRXTestCase(TestCase):
             self.assertTrue((yield self.fifo.r_rdy))
             self.assertEqual((yield self.fifo.r_data), 0x55)
             yield self.fifo.r_en.eq(1)
-            yield
-            yield
+            yield Tick()
             while not (yield self.fifo.r_rdy):
-                yield
+                yield Tick()
             self.assertEqual((yield self.fifo.r_data), 0xAA)
-            yield
+            yield Tick()
             self.assertFalse((yield self.fifo.r_rdy))
         simulation_test(m, process)
 
@@ -315,7 +314,7 @@ class AsyncSerialTXSignatureTestCase(TestCase):
 class AsyncSerialTXTestCase(TestCase):
     def tx_period(self):
         for _ in range((yield self.dut.divisor)):
-            yield
+            yield Tick()
 
     def tx_test(self, data, *, bits, pins=None):
         if pins is not None:
@@ -327,7 +326,7 @@ class AsyncSerialTXTestCase(TestCase):
             yield self.dut.data.eq(data)
             yield self.dut.ack.eq(1)
             while (yield self.dut.rdy):
-                yield
+                yield Tick()
             for bit in bits:
                 yield from self.tx_period()
                 self.assertEqual((yield tx_o), bit)
@@ -396,16 +395,15 @@ class AsyncSerialTXTestCase(TestCase):
             self.assertTrue((yield self.fifo.w_rdy))
             yield self.fifo.w_en.eq(1)
             yield self.fifo.w_data.eq(0x55)
-            yield
+            yield Tick()
             self.assertTrue((yield self.fifo.w_rdy))
             yield self.fifo.w_data.eq(0xAA)
-            yield
+            yield Tick()
             yield self.fifo.w_en.eq(0)
-            yield
             for bit in [0, 1,0,1,0,1,0,1,0, 1]:
                 yield from self.tx_period()
                 self.assertEqual((yield self.dut.o), bit)
-            yield
+            yield Tick()
             for bit in [0, 0,1,0,1,0,1,0,1, 1]:
                 yield from self.tx_period()
                 self.assertEqual((yield self.dut.o), bit)
@@ -525,12 +523,12 @@ class AsyncSerialTestCase(TestCase):
             self.assertTrue((yield self.dut.tx.rdy))
             yield self.dut.tx.data.eq(0xAA)
             yield self.dut.tx.ack.eq(1)
-            yield
+            yield Tick()
             yield self.dut.tx.ack.eq(0)
             yield self.dut.rx.ack.eq(1)
-            yield
+            yield Tick()
             while not (yield self.dut.rx.rdy):
-                yield
+                yield Tick()
             self.assertEqual((yield self.dut.rx.data), 0xAA)
         simulation_test(m, process)
 
@@ -544,11 +542,11 @@ class AsyncSerialTestCase(TestCase):
             self.assertTrue((yield self.dut.tx.rdy))
             yield self.dut.tx.data.eq(0xAA)
             yield self.dut.tx.ack.eq(1)
-            yield
+            yield Tick()
             yield self.dut.tx.ack.eq(0)
             yield self.dut.rx.ack.eq(1)
-            yield
+            yield Tick()
             while not (yield self.dut.rx.rdy):
-                yield
+                yield Tick()
             self.assertEqual((yield self.dut.rx.data), 0xAA)
         simulation_test(m, process)

--- a/tests/test_serial.py
+++ b/tests/test_serial.py
@@ -21,8 +21,8 @@ def simulation_test(dut, process):
 
 class _DummyPins:
     def __init__(self):
-        self.rx = Signal(StructLayout({"i": 1}), reset={"i": 1})
-        self.tx = Signal(StructLayout({"o": 1}), reset={"o": 1})
+        self.rx = Signal(StructLayout({"i": 1}), init={"i": 1})
+        self.tx = Signal(StructLayout({"o": 1}), init={"o": 1})
 
 
 class AsyncSerialRXSignatureTestCase(TestCase):
@@ -33,12 +33,12 @@ class AsyncSerialRXSignatureTestCase(TestCase):
         self.assertEqual(sig.data_bits, 7)
         self.assertEqual(sig.parity, Parity.EVEN)
         self.assertEqual(sig.members, Signature({
-            "divisor": In(unsigned(8), reset=10),
+            "divisor": In(unsigned(8), init=10),
             "data":    Out(unsigned(7)),
             "err":     Out(StructLayout({"overflow": 1, "frame": 1, "parity": 1})),
             "rdy":     Out(unsigned(1)),
             "ack":     In(unsigned(1)),
-            "i":       In(unsigned(1), reset=1),
+            "i":       In(unsigned(1), init=1),
         }).members)
 
     def test_defaults(self):
@@ -67,7 +67,7 @@ class AsyncSerialRXSignatureTestCase(TestCase):
     def test_repr(self):
         sig = AsyncSerialRX.Signature(divisor=10, divisor_bits=8, data_bits=7, parity="even")
         self.assertEqual(repr(sig), "AsyncSerialRX.Signature(SignatureMembers({"
-                                        "'divisor': In(unsigned(8), reset=10), "
+                                        "'divisor': In(unsigned(8), init=10), "
                                         "'data': Out(unsigned(7)), "
                                         "'err': Out(StructLayout({"
                                             "'overflow': 1, "
@@ -75,7 +75,7 @@ class AsyncSerialRXSignatureTestCase(TestCase):
                                             "'parity': 1})), "
                                         "'rdy': Out(unsigned(1)), "
                                         "'ack': In(unsigned(1)), "
-                                        "'i': In(unsigned(1), reset=1)}))")
+                                        "'i': In(unsigned(1), init=1)}))")
 
     def test_wrong_divisor(self):
         with self.assertRaisesRegex(TypeError,
@@ -242,11 +242,11 @@ class AsyncSerialTXSignatureTestCase(TestCase):
         self.assertEqual(sig.data_bits, 7)
         self.assertEqual(sig.parity, Parity.EVEN)
         self.assertEqual(sig.members, Signature({
-            "divisor": In(unsigned(8), reset=10),
+            "divisor": In(unsigned(8), init=10),
             "data":    In(unsigned(7)),
             "rdy":     Out(unsigned(1)),
             "ack":     In(unsigned(1)),
-            "o":       Out(unsigned(1), reset=1),
+            "o":       Out(unsigned(1), init=1),
         }).members)
 
     def test_defaults(self):
@@ -275,11 +275,11 @@ class AsyncSerialTXSignatureTestCase(TestCase):
     def test_repr(self):
         sig = AsyncSerialTX.Signature(divisor=10, divisor_bits=8, data_bits=7, parity="even")
         self.assertEqual(repr(sig), "AsyncSerialTX.Signature(SignatureMembers({"
-                                        "'divisor': In(unsigned(8), reset=10), "
+                                        "'divisor': In(unsigned(8), init=10), "
                                         "'data': In(unsigned(7)), "
                                         "'rdy': Out(unsigned(1)), "
                                         "'ack': In(unsigned(1)), "
-                                        "'o': Out(unsigned(1), reset=1)}))")
+                                        "'o': Out(unsigned(1), init=1)}))")
 
     def test_wrong_divisor(self):
         with self.assertRaisesRegex(TypeError,
@@ -420,7 +420,7 @@ class AsyncSerialSignatureTestCase(TestCase):
         self.assertEqual(sig.data_bits, 7)
         self.assertEqual(sig.parity, Parity.EVEN)
         self.assertEqual(sig.members, Signature({
-            "divisor": In(unsigned(8), reset=10),
+            "divisor": In(unsigned(8), init=10),
             "rx": Out(AsyncSerialRX.Signature(divisor=10, divisor_bits=8, data_bits=7, parity="even")),
             "tx": Out(AsyncSerialTX.Signature(divisor=10, divisor_bits=8, data_bits=7, parity="even")),
         }).members)
@@ -451,9 +451,9 @@ class AsyncSerialSignatureTestCase(TestCase):
     def test_repr(self):
         sig = AsyncSerial.Signature(divisor=10, divisor_bits=8, data_bits=7, parity="even")
         self.assertEqual(repr(sig), "AsyncSerial.Signature(SignatureMembers({"
-                                        "'divisor': In(unsigned(8), reset=10), "
+                                        "'divisor': In(unsigned(8), init=10), "
                                         "'rx': Out(AsyncSerialRX.Signature(SignatureMembers({"
-                                            "'divisor': In(unsigned(8), reset=10), "
+                                            "'divisor': In(unsigned(8), init=10), "
                                             "'data': Out(unsigned(7)), "
                                             "'err': Out(StructLayout({"
                                                 "'overflow': 1, "
@@ -461,13 +461,13 @@ class AsyncSerialSignatureTestCase(TestCase):
                                                 "'parity': 1})), "
                                             "'rdy': Out(unsigned(1)), "
                                             "'ack': In(unsigned(1)), "
-                                            "'i': In(unsigned(1), reset=1)}))), "
+                                            "'i': In(unsigned(1), init=1)}))), "
                                         "'tx': Out(AsyncSerialTX.Signature(SignatureMembers({"
-                                            "'divisor': In(unsigned(8), reset=10), "
+                                            "'divisor': In(unsigned(8), init=10), "
                                             "'data': In(unsigned(7)), "
                                             "'rdy': Out(unsigned(1)), "
                                             "'ack': In(unsigned(1)), "
-                                            "'o': Out(unsigned(1), reset=1)})))}))")
+                                            "'o': Out(unsigned(1), init=1)})))}))")
 
     def test_wrong_divisor(self):
         with self.assertRaisesRegex(TypeError,


### PR DESCRIPTION
This makes the package unbuildable on Amaranth 0.4. Unfortunately there's no way to stay compatible with both, and migration is necessary to enable downstream code to build with `PYTHONWARNINGS=error`.